### PR TITLE
Add rubyXL convenience methods to support Rails 6

### DIFF
--- a/lib/rails_exporter/exporter.rb
+++ b/lib/rails_exporter/exporter.rb
@@ -1,6 +1,7 @@
 require 'builder'
 require 'spreadsheet'
 require 'rubyXL'
+require 'rubyXL/convenience_methods'
 
 module RailsExporter
   module Exporter

--- a/rails_exporter.gemspec
+++ b/rails_exporter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   spec.test_files = Dir['spec/**/*']
 
-  spec.add_dependency 'rails', ['>= 3', '< 6']
+  spec.add_dependency 'rails', ['>= 3']
   spec.add_dependency 'rubyXL', '~> 3.3'
   spec.add_dependency 'spreadsheet', '~> 1.1'
   spec.add_dependency 'builder', '~> 3.0'


### PR DESCRIPTION
I noticed the current version supported only up to but not including Rails 6.  I've added the convenience methods needed to allow the gem to work with the new API for rubyXL.

I'm successfully running this in a Rails 6 application, but was not sure how to add proper tests for specific versions of Rails.  Instead, I was able to update the dependency to force the version of Rails you created this with (5.1 I believe) and also 6.  Once tested that specs pass, I reverted the dependency to just be at least Rails 3 again.

[rubyXL Convenience Methods](https://www.rubydoc.info/gems/rubyXL/3.4.2#label-Convenience+methods)